### PR TITLE
Updated Twitter Logo to X logo

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -66,7 +66,7 @@ author:
       icon: "fas fa-fw fa-link"
       url: "https://"
     - label: "Twitter"
-      icon: "fab fa-fw fa-twitter-square"
+      icon: "fab fa-brands fa-x-twitter"
       url: "https://twitter.com/"
     - label: "GitHub"
       icon: "fab fa-fw fa-github"
@@ -78,7 +78,7 @@ author:
 footer:
   links:
     - label: "Twitter"
-      icon: "fab fa-fw fa-twitter-square"
+      icon: "fab fa-brands fa-x-twitter"
       url: "https://twitter.com/"
     - label: "GitHub"
       icon: "fab fa-fw fa-github"


### PR DESCRIPTION
I changed the old twitter logo to the new X logo. I left the word Twitter as colloquially people tend to say Twitter, not X in my experience.